### PR TITLE
Add support for reactions log

### DIFF
--- a/Facebook-Delete-ActivityLog-SearchHistory.js
+++ b/Facebook-Delete-ActivityLog-SearchHistory.js
@@ -6,6 +6,7 @@ function deleteFacebookActivityLog_SearchHistory(index = 0, currentAttempt = 0) 
     "Remove reaction",
     "Unlike",
     "Delete Your Activity",
+    "Move to bin",
   ]
 
   // Increment attempt count
@@ -33,7 +34,17 @@ function deleteFacebookActivityLog_SearchHistory(index = 0, currentAttempt = 0) 
           var opt = opts[i];
           // If the innerText is one of the values in the array, then we can deletefaczb
           if (innerTextValues.includes(opt.innerText)) {
-              var ariaLabel = opt.innerText === "Move to trash" ? "Move to Trash" : "Delete";
+              let ariaLabel;
+              // If innerText is "Move to trash", set ariaLabel to "Move to trash" (for history logs)
+              if (opt.innerText === "Move to trash") {
+                  ariaLabel = opt.innerText;
+              // If innerText is "Move to bin", then ariaLabel should be "Move to Recycle bin" (FB UI...) (for posts logs)
+              } else if (opt.innerText === "Move to bin") {
+                  ariaLabel = "Move to Recycle bin";
+              // Otherwise, set ariaLabel to "Delete" (default for all other logs)
+              } else {
+                  ariaLabel = "Delete";
+              }
               canDelete = true;
               opt.click();
               setTimeout(() => {

--- a/Facebook-Delete-ActivityLog-SearchHistory.js
+++ b/Facebook-Delete-ActivityLog-SearchHistory.js
@@ -1,4 +1,12 @@
 function deleteFacebookActivityLog_SearchHistory(index = 0) {
+  // Var to store the different values for innerText
+  var innerTextValues = [
+    "Move to trash",
+    "Delete",
+    "Remove reaction",
+    "Unlike",
+  ]
+
   var items = document.querySelectorAll('[aria-label="Action options"] > i');
   var item = items[index]
 
@@ -12,21 +20,22 @@ function deleteFacebookActivityLog_SearchHistory(index = 0) {
       var canDelete = false
       for (let i=0; i < opts.length; i += 1) {
           var opt = opts[i];
-          if (opt.innerText === "Move to trash" || opt.innerText === "Delete" || opt.innerText === "Remove reaction" || opt.innerText === "Unlike") {
-          var ariaLabel = opt.innerText === "Move to trash" ? "Move to Trash" : "Delete";
-          canDelete = true;
-          opt.click();
-          setTimeout(() => {
-              var confirm = document.querySelector(`[aria-label="${ariaLabel}"][tabindex="0"]`);
-              if (confirm) {
-              confirm.click();
-              }
+          // If the innerText is one of the values in the array, then we can delete
+          if (innerTextValues.includes(opt.innerText)) {
+              var ariaLabel = opt.innerText === "Move to trash" ? "Move to Trash" : "Delete";
+              canDelete = true;
+              opt.click();
               setTimeout(() => {
-                deleteFacebookActivityLog_SearchHistory(index);
-              console.log("Activity deleted");
-              }, 2000);
-          }, 250);
-          break;
+                  var confirm = document.querySelector(`[aria-label="${ariaLabel}"][tabindex="0"]`);
+                  if (confirm) {
+                  confirm.click();
+                  }
+                  setTimeout(() => {
+                    deleteFacebookActivityLog_SearchHistory(index);
+                  console.log("Activity deleted");
+                  }, 2000);
+              }, 250);
+              break;
           }
       }
       if (!canDelete) {

--- a/Facebook-Delete-ActivityLog-SearchHistory.js
+++ b/Facebook-Delete-ActivityLog-SearchHistory.js
@@ -1,3 +1,5 @@
+const attemptCounts = {}; // Track attempts per index
+
 function deleteFacebookActivityLog_SearchHistory(index = 0) {
   // Var to store the different values for innerText
   var innerTextValues = [
@@ -6,6 +8,16 @@ function deleteFacebookActivityLog_SearchHistory(index = 0) {
     "Remove reaction",
     "Unlike",
   ]
+
+  // Increment attempt count for this index
+  attemptCounts[index] = (attemptCounts[index] || 0) + 1;
+
+  // If tried more than twice, skip to next
+  if (attemptCounts[index] > 2) {
+    console.log(`Skipping index ${index} after 2 failed attempts.`);
+    deleteFacebookActivityLog_SearchHistory(index + 1);
+    return;
+  }
 
   var items = document.querySelectorAll('[aria-label="Action options"] > i');
   var item = items[index]
@@ -20,7 +32,7 @@ function deleteFacebookActivityLog_SearchHistory(index = 0) {
       var canDelete = false
       for (let i=0; i < opts.length; i += 1) {
           var opt = opts[i];
-          // If the innerText is one of the values in the array, then we can delete
+          // If the innerText is one of the values in the array, then we can deletefaczb
           if (innerTextValues.includes(opt.innerText)) {
               var ariaLabel = opt.innerText === "Move to trash" ? "Move to Trash" : "Delete";
               canDelete = true;

--- a/Facebook-Delete-ActivityLog-SearchHistory.js
+++ b/Facebook-Delete-ActivityLog-SearchHistory.js
@@ -1,28 +1,27 @@
-const attemptCounts = {}; // Track attempts per index
-
-function deleteFacebookActivityLog_SearchHistory(index = 0) {
+function deleteFacebookActivityLog_SearchHistory(index = 0, currentAttempt = 0) {
   // Var to store the different values for innerText
   var innerTextValues = [
     "Move to trash",
     "Delete",
     "Remove reaction",
     "Unlike",
+    "Delete Your Activity",
   ]
 
-  // Increment attempt count for this index
-  attemptCounts[index] = (attemptCounts[index] || 0) + 1;
+  // Increment attempt count
+  currentAttempt++;
 
-  // If tried more than twice, skip to next
-  if (attemptCounts[index] > 2) {
-    console.log(`Skipping index ${index} after 2 failed attempts.`);
-    deleteFacebookActivityLog_SearchHistory(index + 1);
-    return;
+  // If tried more than two times, go to the next item
+  if (currentAttempt > 2) {
+    console.log("Tried too many times, going to next item"); 
+    return deleteFacebookActivityLog_SearchHistory(index + 1, 0);
   }
 
   var items = document.querySelectorAll('[aria-label="Action options"] > i');
   var item = items[index]
 
   if (item) {
+      var logIdentifier = item.parentNode.parentNode.parentNode.innerText.trim();
       console.log("ACTIVITY-LOG => ", item.parentNode.parentNode.parentNode.innerText);
           
       item.scrollIntoView();
@@ -43,8 +42,23 @@ function deleteFacebookActivityLog_SearchHistory(index = 0) {
                   confirm.click();
                   }
                   setTimeout(() => {
-                    deleteFacebookActivityLog_SearchHistory(index);
-                  console.log("Activity deleted");
+                      // After deletion attempt, check if the same log line is still present at the same index
+                      var newItems = document.querySelectorAll('[aria-label="Action options"] > i');
+                      var newItem = newItems[index];
+                      var stillSame = false;
+                      if (newItem) {
+                        var newIdentifier = newItem.parentNode.parentNode.parentNode.innerText.trim();
+                        stillSame = (newIdentifier === logIdentifier);
+                      }
+                      if (stillSame) {
+                        // Deletion failed, try again
+                        console.log("Deletion failed, retrying...");
+                        deleteFacebookActivityLog_SearchHistory(index, currentAttempt);
+                      } else {
+                        // Deletion succeeded, move to next
+                        console.log("Activity deleted");
+                        deleteFacebookActivityLog_SearchHistory(index, 0);
+              }
                   }, 2000);
               }, 250);
               break;
@@ -52,7 +66,7 @@ function deleteFacebookActivityLog_SearchHistory(index = 0) {
       }
       if (!canDelete) {
           setTimeout(() => {
-            deleteFacebookActivityLog_SearchHistory(index + 1);
+            deleteFacebookActivityLog_SearchHistory(index + 1, 0);
           console.log("Nothing to do");
           }, 250);
       }

--- a/Facebook-Delete-ActivityLog-SearchHistory.js
+++ b/Facebook-Delete-ActivityLog-SearchHistory.js
@@ -12,7 +12,7 @@ function deleteFacebookActivityLog_SearchHistory(index = 0) {
       var canDelete = false
       for (let i=0; i < opts.length; i += 1) {
           var opt = opts[i];
-          if (opt.innerText === "Move to trash" || opt.innerText === "Delete") {
+          if (opt.innerText === "Move to trash" || opt.innerText === "Delete" || opt.innerText === "Remove reaction" || opt.innerText === "Unlike") {
           var ariaLabel = opt.innerText === "Move to trash" ? "Move to Trash" : "Delete";
           canDelete = true;
           opt.click();


### PR DESCRIPTION
Hi,

First of all, thanks for the script, I am no JS wizard and it helped me a lot. I noticed you wrote that you wanted to test each different activity logs before compiling everything in one script, but your Readme only mentions one script. 

So I tested it on the following logs : 

- _Group posts and comments_
- _Comments and reactions_
- _Your reactions to posts in groups_

For the last two to work, and this is my PR, I added to other text to check against the `innerText` var, and their further rationalized it by putting it in an upper constant, making it easier to edit.

Sometimes the script seems to stop working and I have to relaunch it by hand, but it happened before I did this edit, and I guess this kind of script is doomed to be buggy, seeing how complicated Facebook UI is ?